### PR TITLE
Add Flask integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Probabilistic Deterministic Automaton
+
+Este repositorio contiene una implementación sencilla en Python de un Autómata Probabilístico Determinista (APD) basado en la propuesta del usuario.
+
+El archivo `automaton.py` define una clase `ProbabilisticDeterministicAutomaton` con los siguientes elementos:
+
+- **Estados:** `S0` a `S11`.
+- **Eventos (alfabeto):** `login`, `failed_login`, `read_file`, `write_file`, `upload_script`, `execute_binary`, `access_admin`, `create_user`, `change_config`, `open_port`, `download_data`, `logout`.
+- **Estado inicial:** `S0`.
+- **Estados de aceptación:** `S6`, `S7`, `S8`, `S9`, `S10`.
+- **Transiciones con probabilidades:** codificadas según la tabla proporcionada.
+
+## Uso rápido
+
+```bash
+python automaton.py
+```
+
+El script ejecutará un ejemplo de secuencia de eventos y mostrará el estado final, la probabilidad total de la secuencia y si dicho estado es de aceptación.
+
+También se puede usar el módulo desde otro script importando la clase `ProbabilisticDeterministicAutomaton` y utilizando los métodos `process_event` o `process_sequence`.
+
+
+## Integración con Flask
+
+Se incluye un pequeño servidor Flask (`app.py`) que expone un endpoint `/process`. Este servicio permite enviar una secuencia de eventos en formato JSON y devuelve el estado final alcanzado, la probabilidad acumulada y si dicho estado es de aceptación.
+
+### Ejecución
+
+1. Instalar dependencias (solo Flask):
+
+```bash
+pip install Flask
+```
+
+2. Iniciar el servidor:
+
+```bash
+python app.py
+```
+
+3. Enviar una secuencia de ejemplo usando `curl` u otra herramienta:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"events": ["login", "read_file", "upload_script", "execute_binary"]}' \
+     http://localhost:5000/process
+```
+
+El servicio responderá con un JSON que incluye el estado final, la probabilidad calculada y si se trata de un estado de aceptación.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,24 @@
+from flask import Flask, request, jsonify
+from automaton import ProbabilisticDeterministicAutomaton
+
+app = Flask(__name__)
+automaton = ProbabilisticDeterministicAutomaton()
+
+@app.route('/process', methods=['POST'])
+def process_events():
+    data = request.get_json(force=True)
+    events = data.get('events', [])
+    if not isinstance(events, list):
+        return jsonify({'error': 'events must be a list'}), 400
+    try:
+        state, probability = automaton.process_sequence(events)
+        return jsonify({
+            'final_state': state,
+            'probability': probability,
+            'accepting': automaton.is_accepting()
+        })
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 400
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/automaton.py
+++ b/automaton.py
@@ -1,0 +1,79 @@
+class ProbabilisticDeterministicAutomaton:
+    def __init__(self):
+        # States
+        self.states = {"S0", "S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8", "S9", "S10", "S11"}
+
+        # Alphabet
+        self.events = {
+            'login', 'failed_login', 'read_file', 'write_file', 'upload_script',
+            'execute_binary', 'access_admin', 'create_user', 'change_config',
+            'open_port', 'download_data', 'logout'
+        }
+
+        # Initial state
+        self.initial_state = 'S0'
+
+        # Final/accepting states
+        self.final_states = {'S6', 'S7', 'S8', 'S9', 'S10'}
+
+        # Transition table with probabilities
+        self.transitions = {
+            ('S0', 'login'): ('S1', 0.95),
+            ('S0', 'failed_login'): ('S5', 0.85),
+            ('S5', 'failed_login'): ('S5', 0.65),
+            ('S1', 'read_file'): ('S2', 0.80),
+            ('S1', 'write_file'): ('S3', 0.70),
+            ('S1', 'upload_script'): ('S4', 0.30),
+            ('S2', 'upload_script'): ('S4', 0.30),
+            ('S3', 'upload_script'): ('S4', 0.30),
+            ('S1', 'execute_binary'): ('S6', 0.20),
+            ('S4', 'execute_binary'): ('S6', 0.20),
+            ('S1', 'access_admin'): ('S7', 0.15),
+            ('S5', 'access_admin'): ('S7', 0.10),
+            ('S6', 'access_admin'): ('S7', 0.15),
+            ('S7', 'create_user'): ('S8', 0.10),
+            ('S8', 'change_config'): ('S9', 0.05),
+            ('S9', 'open_port'): ('S10', 0.03),
+            ('S1', 'download_data'): ('S11', 0.40),
+            ('S1', 'logout'): ('S0', 0.90),
+        }
+
+        # Current state
+        self.current_state = self.initial_state
+        # Probability of reaching current state via processed sequence
+        self.current_probability = 1.0
+
+    def reset(self):
+        """Reset automaton to the initial state."""
+        self.current_state = self.initial_state
+        self.current_probability = 1.0
+
+    def process_event(self, event):
+        """Process a single event and update state and probability."""
+        if (self.current_state, event) not in self.transitions:
+            raise ValueError(f"No transition defined for state {self.current_state} with event {event}")
+        next_state, probability = self.transitions[(self.current_state, event)]
+        self.current_state = next_state
+        self.current_probability *= probability
+        return self.current_state, probability
+
+    def process_sequence(self, events):
+        """Process a sequence of events."""
+        self.reset()
+        for event in events:
+            self.process_event(event)
+        return self.current_state, self.current_probability
+
+    def is_accepting(self):
+        """Check if current state is an accepting state."""
+        return self.current_state in self.final_states
+
+
+if __name__ == "__main__":
+    # Example usage: process a sample sequence
+    automaton = ProbabilisticDeterministicAutomaton()
+    sequence = ['login', 'read_file', 'upload_script', 'execute_binary']
+    state, prob = automaton.process_sequence(sequence)
+    print(f"Final state: {state}")
+    print(f"Probability: {prob:.4f}")
+    print(f"Accepting: {automaton.is_accepting()}")


### PR DESCRIPTION
## Summary
- integrate automaton with a minimal Flask service
- document how to use the service in README

## Testing
- `python automaton.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68651ec15678832192b0df1149d3ba76